### PR TITLE
feat(cli): support spotDL save files for resync

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -24,7 +24,7 @@ Paste a URL, and the `mdl` resolves music metadata, searches YouTube for matches
 - All providers work without API keys, we query via public urls
 - Downloads are grouped into a music name directory
 - A `.mdl.json` manifest is written next to the files for resyncs
-- If no `.mdl.json` is found, an existing `.spotdl` sync file in the directory is used to detect the playlist URL for a resync
+- If no `.mdl.json` is found, an existing spotDL `.spotdl` sync or save file is used to detect the collection URL for a resync
 - Metadata is resolved directly from the music URL
 - Audio is sourced from YouTube
 

--- a/packages/cli/src/lib/schemas.ts
+++ b/packages/cli/src/lib/schemas.ts
@@ -68,3 +68,5 @@ export const spotdlSaveFileSchema = Schema.Struct({
   query: Schema.Array(Schema.String),
   songs: Schema.Array(spotdlSongSchema),
 });
+
+export const spotdlMetadataFileSchema = Schema.Array(spotdlSongSchema);

--- a/packages/cli/src/lib/spotdl.test.ts
+++ b/packages/cli/src/lib/spotdl.test.ts
@@ -51,6 +51,36 @@ describe('spotdl', () => {
     );
   });
 
+  test('loadSpotdlManifest extracts album metadata from a spotDL save file', async () => {
+    const directory = await createTemporaryDirectory();
+    await writeFile(
+      path.join(directory, 'meta.spotdl'),
+      JSON.stringify([
+        {
+          name: 'Inertia',
+          artists: ['squeeda', 'tonbo', 'Lofi Girl'],
+          album_name: 'Best-of lofi hip-hop 2023',
+          song_id: '6wRHaOcokW7CxVDtIWAtwi',
+          url: 'https://open.spotify.com/track/6wRHaOcokW7CxVDtIWAtwi',
+          list_name: 'Best-of lofi hip-hop 2023',
+          list_url: 'https://open.spotify.com/album/5wJIyaro488CBphiDI8bu5?si=QyLo6h_MSfyuxp73f9I8dw',
+        },
+      ])
+    );
+
+    const manifest = await loadSpotdlManifest(directory);
+
+    expect(manifest).toEqual(
+      expect.objectContaining({
+        provider: 'spotify',
+        playlistId: '5wJIyaro488CBphiDI8bu5',
+        playlistTitle: 'Best-of lofi hip-hop 2023',
+        playlistUrl: 'https://open.spotify.com/album/5wJIyaro488CBphiDI8bu5?si=QyLo6h_MSfyuxp73f9I8dw',
+        tracks: [],
+      })
+    );
+  });
+
   test('loadSpotdlManifest falls back to the first song list_url when query is empty', async () => {
     const directory = await createTemporaryDirectory();
     await writeFile(

--- a/packages/cli/src/lib/spotdl.ts
+++ b/packages/cli/src/lib/spotdl.ts
@@ -2,7 +2,7 @@ import { readdir, readFile } from 'node:fs/promises';
 import path from 'node:path';
 import { Either } from 'effect';
 import { detectProvider } from './providers/Providers';
-import { spotdlSaveFileSchema } from './schemas';
+import { spotdlMetadataFileSchema, spotdlSaveFileSchema } from './schemas';
 import type { SyncManifest } from './types';
 import { decodeUnknownEither, getFirstNonEmptyString } from './utils';
 
@@ -40,13 +40,20 @@ async function findSpotdlFiles(directory: string): Promise<string[]> {
 
 function parseSpotdlSaveFile(value: unknown): SyncManifest | null {
   const saveFileResult = decodeUnknownEither(spotdlSaveFileSchema, value);
-  if (Either.isLeft(saveFileResult)) {
-    return null;
+  if (Either.isRight(saveFileResult)) {
+    return parseSpotdlCollection(saveFileResult.right.songs, saveFileResult.right.query);
   }
 
-  const saveFile = saveFileResult.right;
-  const firstSong = saveFile.songs?.[0];
-  const collection = [firstSong?.list_url, saveFile.query[0]]
+  const metadataFileResult = decodeUnknownEither(spotdlMetadataFileSchema, value);
+  return Either.isRight(metadataFileResult) ? parseSpotdlCollection(metadataFileResult.right, []) : null;
+}
+
+function parseSpotdlCollection(
+  songs: ReadonlyArray<{ list_name: string | null; list_url: string | null }>,
+  query: ReadonlyArray<string>
+): SyncManifest | null {
+  const firstSong = songs[0];
+  const collection = [firstSong?.list_url, query[0]]
     .map(parseSpotifyCollection)
     .find((candidate) => candidate !== null);
 


### PR DESCRIPTION
## Summary

- detect current spotDL `save` metadata files in addition to legacy `sync` files
- use only collection URLs from saved metadata; track URLs remain rejected
- document supported spotDL file formats

## Validation

- `bun run --filter '@mdlx/cli' test:unit`\n- `bun run --filter '@mdlx/cli' typecheck`\n- `bunx biome check packages/cli/src/lib/schemas.ts packages/cli/src/lib/spotdl.ts packages/cli/src/lib/spotdl.test.ts packages/cli/README.md`